### PR TITLE
Fix/add new interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,13 @@
 
 import express = require('express');
 
+declare module 'passport' {
+    export interface AuthenticateOptions {
+        callbackURL: string,
+        prompt: string
+    }
+}
+
 declare namespace passport_openidconnect {
 
     class AcpStrategy {
@@ -22,6 +29,7 @@ declare namespace passport_openidconnect {
                                      profile?: OICProfile,
                                      accessToken?: string,
                                      refreshToken?: string,
+                                     params?: any,
                                      callback?: (err: string, user: any, info: string) => void) => void;
 
     interface OICProfile {
@@ -44,7 +52,7 @@ declare namespace passport_openidconnect {
         userInfoURL: string,
         clientID: string,
         clientSecret: string,
-        callbackURL: string,
+        callbackURL?: string,
         scope: string,
         passReqToCallback?: boolean,
         prompt?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare namespace passport_openidconnect {
         userInfoURL: string,
         clientID: string,
         clientSecret: string,
-        callbackURL?: string,
+        callbackURL: string,
         scope: string,
         passReqToCallback?: boolean,
         prompt?: string


### PR DESCRIPTION
Matching the interface signature we have implemented for Atlas' implementation. These are only additive changes, so should be back-compat.

Regarding adding `params` to `strategyCallBackFunction` type: `params` is an object that can be passed in to the strategy callback if the callback's arity is 7+ (if `passReqToCallback` is false) or 8+ (if `passReqToCallback` is true). Some apps (Atlas, Scout) have implemented callbacks w/ such arities, so adding `params` as an optional param. OAuth itself doesn't define the proper type of `params`, so leaving it as `any` here