### PR TITLE
remove pkg info, major version bump since api is removed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
 Changelog: 
- Release v1.0.7 to v1.0.7
+ Release v.0.7 to v2.0.0
+
+ Removed `pkginfo` dependency
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 Changelog: 
  Release v.0.7 to v2.0.0
 
- Removed `pkginfo` dependency
+ Removed `pkginfo` dependency, removes `version` from being exposed
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,12 +4,6 @@
 var AcpStrategy = require('./strategy')
   , setup = require('./setup')
 
-
-/**
- * Framework version.
- */
-require('pkginfo')(module, 'version');
-
 /**
  * Expose constructors.
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-openidconnect",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "OpenID Connect authentication strategy for Passport. Modified by Accolade.",
   "repository": {
     "type": "git",
@@ -29,7 +29,6 @@
     "@types/passport": "0.3.4",
     "oauth": "0.9.x",
     "passport": "0.4.1",
-    "pkginfo": "0.2.x",
     "webfinger": "0.3.x"
   },
   "devDependencies": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -3,10 +3,6 @@ var openid = require('index');
 
 describe('passport-openid', function() {
     
-  it('should export version', function() {
-    expect(openid.version).to.be.a('string');
-  });
-    
   it('should export Strategy', function() {
     expect(openid.AcpStrategy).to.be.a('function');
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,10 +172,6 @@ pause@0.0.1:
   version "0.0.1"
   resolved "https://accolade.jfrog.io/accolade/api/npm/npm-virtual/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
 
-pkginfo@0.2.x:
-  version "0.2.3"
-  resolved "https://accolade.jfrog.io/accolade/api/npm/npm-virtual/pkginfo/-/pkginfo-0.2.3.tgz#7239c42a5ef6c30b8f328439d9b9ff71042490f8"
-
 sax@>=0.1.1:
   version "1.2.2"
   resolved "https://accolade.jfrog.io/accolade/api/npm/npm-virtual/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"


### PR DESCRIPTION
removes pkginfo from from package json.

removes `version` property that was exposed on openid connect object.

major version bump to account for this breaking change